### PR TITLE
Add Docker image for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ os = linux
 dapperdox-version = 1.1.1
 
 test-url = http://localhost/
+token = DUMMY
+username = test
+client = test
 
-.PHONY: all clean listen test deps dapperbox dapperbox-theme-gov-uk dredd npm
+.PHONY: all clean dapperbox dapperbox-theme-gov-uk deps deps-listen deps-test dredd docker docker-test listen npm test
 
 all: deps test listen
 
@@ -13,13 +16,28 @@ clean:
 	rm -rf ".deps/node_modules/"
 	rm -f "bin/dredd"
 
-listen: dapperdox dapperdox-theme-gov-uk
+listen: deps-listen
 	bin/dapperdox
 
-test: dredd
-	bin/dredd "./swagger.yaml" "$(test-url)" -h "X-Auth-Username: test" -h "X-Auth-Aud: test"
+test: deps-test
+	bin/dredd "./swagger.yaml" "$(test-url)" \
+	          -h "Authorization: Bearer $(token)" \
+	          -h "X-Auth-Username: $(username)" \
+	          -h "X-Auth-Aud: $(client)"
 
-deps: dapperdox dapperdox-theme-gov-uk dredd
+docker: docker-test
+
+docker-test: deps-test
+	docker build \
+	       -t lev-api-test \
+	       -f ./test.Dockerfile \
+	       .
+
+deps: deps-listen deps-test
+
+deps-listen: dapperdox dapperdox-theme-gov-uk
+
+deps-test: dredd
 
 dapperdox: .deps/dapperdox
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,21 @@
+FROM node:9-alpine
+
+RUN apk add --no-cache curl jq \
+ && addgroup -S "app" \
+ && adduser -Sh "/app" "app" "app"
+
+USER app
+WORKDIR /app
+
+RUN mkdir -p ./bin/
+
+COPY ./.deps/node_modules/ ./.deps/node_modules/
+RUN ln -fs "../.deps/node_modules/.bin/dredd" "bin/dredd"
+COPY ./test.entrypoint.sh ./entrypoint.sh
+COPY ./swagger.yaml ./swagger.yaml
+
+USER root
+RUN chown -R "app:app" .
+
+USER app
+CMD ["./entrypoint.sh"]

--- a/test.entrypoint.sh
+++ b/test.entrypoint.sh
@@ -1,0 +1,30 @@
+#! /bin/sh
+
+set -e
+
+TEST_URL="${TEST_URL:-http://localhost/}"
+OIDC_URL="${OIDC_URL}"
+USERNAME="${USERNAME:-test}"
+PASSWORD="${PASSWORD}"
+CLIENT_ID="${CLIENT_ID:-test}"
+CLIENT_SECRET="${CLIENT_SECRET}"
+
+DEBUG="${DEBUG}"
+
+dredd="./bin/dredd ./swagger.yaml ${TEST_URL}"
+token="DUMMY"
+
+if [ -n  "${OIDC_URL}" ]; then
+  echo "Requesting access token from ${OIDC_URL} for user, '${USERNAME}', as client, '${CLIENT_ID}'..."
+  payload=`curl "${OIDC_URL}/token" -X POST \
+              -H "Accept: */*" \
+              -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&username=${USERNAME}&password=${PASSWORD}&grant_type=password"`
+  [ -n "${DEBUG}" ] && echo "Received payload: ${payload}"
+  token=`echo "${payload}" | jq -rM ".access_token"`
+  [ -n "${DEBUG}" ] && echo "Parsed out token: ${token}"
+  echo "Starting tests with OAuth2 bearer token..."
+  ${dredd} -h "Authorization: Bearer ${token}"
+else
+  echo "Starting tests..."
+  ${dredd} -h "X-Auth-Username: ${USERNAME}" -h "X-Auth-Aud: ${CLIENT_ID}"
+fi


### PR DESCRIPTION
Add Docker image for both end-to-end and acceptance testing.

The image can be built using `make docker`. Later on we will hook this up into a CI pipeline.