### PR TITLE
Fail on failed token request

### DIFF
--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,23 +1,16 @@
-FROM node:9-alpine
+FROM node:8-alpine
 
 RUN apk add --no-cache curl jq \
- && apk upgrade --no-cache \
- && addgroup -S "app" \
- && adduser -Sh "/app" "app" "app"
+ && apk upgrade --no-cache
 
-USER app
-WORKDIR /app
+WORKDIR /home/node
 
 RUN mkdir -p ./bin/
-
 COPY ./.deps/node_modules/ ./.deps/node_modules/
 RUN ln -fs "../.deps/node_modules/.bin/dredd" "bin/dredd"
 COPY ./test.entrypoint.sh ./entrypoint.sh
 COPY ./swagger.yaml ./swagger.yaml
+RUN chown -R "node:node" .
 
-USER root
-RUN chown -R "app:app" . \
- && apk upgrade --no-cache
-
-USER app
+USER node
 CMD ["./entrypoint.sh"]

--- a/test.entrypoint.sh
+++ b/test.entrypoint.sh
@@ -15,6 +15,10 @@ DEBUG="${DEBUG}"
 dredd="./bin/dredd ./swagger.yaml ${TEST_URL}"
 token="DUMMY"
 
+function esc {
+    echo "${1//&/\\&}"
+}
+
 probe_api="curl -fs '${TEST_URL}/readiness' &> /dev/null"
 
 if [ -n "${WAIT}" ]; then
@@ -32,9 +36,9 @@ fi
 
 if [ -n  "${OIDC_URL}" ]; then
   echo "Requesting access token from ${OIDC_URL} for user, '${USERNAME}', as client, '${CLIENT_ID}'..."
-  payload=`curl "${OIDC_URL}/token" -X POST \
+  payload=$(curl -f "${OIDC_URL}/token" -X POST \
               -H "Accept: */*" \
-              -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&username=${USERNAME}&password=${PASSWORD}&grant_type=password"`
+              -d "client_id=`esc ${CLIENT_ID}`&client_secret=`esc ${CLIENT_SECRET}`&username=`esc ${USERNAME}`&password=`esc ${PASSWORD}`&grant_type=password")
   [ -n "${DEBUG}" ] && echo "Received payload: ${payload}"
   token=`echo "${payload}" | jq -rM ".access_token"`
   [ -n "${DEBUG}" ] && echo "Parsed out token: ${token}"


### PR DESCRIPTION
Cause the script to fail fast when the OpenID Connect (OIDC) endpoint
responds with an error.

Also escapes ampersands from the post-data parameters.