### PR TITLE
Improve the default user and client names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ dapperdox-version = 1.1.1
 
 test-url = http://localhost/
 token = DUMMY
-username = test
-client = test
+username = $(USER)
+client = dredd
 
 .PHONY: all clean dapperbox dapperbox-theme-gov-uk deps deps-docs deps-test dredd docker docker-docs docker-test docs npm test
 

--- a/test.entrypoint.sh
+++ b/test.entrypoint.sh
@@ -4,9 +4,9 @@ set -e
 
 TEST_URL="${TEST_URL:-http://localhost/}"
 OIDC_URL="${OIDC_URL}"
-USERNAME="${USERNAME:-test}"
+USERNAME="${USERNAME:-${USER:-test}}"
 PASSWORD="${PASSWORD}"
-CLIENT_ID="${CLIENT_ID:-test}"
+CLIENT_ID="${CLIENT_ID:-dredd}"
 CLIENT_SECRET="${CLIENT_SECRET}"
 WAIT="${WAIT}"
 


### PR DESCRIPTION
Improves the default user and client names when testing without OpenID
Connect. The username defaults to the current POSIX user and the client
defaults to 'dredd'.