### PR TITLE
Simplify docs Docker image

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -1,6 +1,4 @@
 FROM scratch
-COPY docs.group /etc/group
-COPY docs.passwd /etc/passwd
 
 ENV BIND_ADDR 0.0.0.0:3123
 EXPOSE 3123
@@ -11,5 +9,5 @@ COPY .deps/dapperdox-theme-gov-uk /assets/themes/gov-uk
 COPY assets/ /assets
 COPY swagger.yaml /spec/
 
-USER 1
+USER 31337
 ENTRYPOINT ["/dapperdox", "--spec-filename=swagger.yaml", "--theme=gov-uk", "--assets-dir", "assets"]

--- a/docs.group
+++ b/docs.group
@@ -1,1 +1,0 @@
-notroot:x:1:notroot

--- a/docs.passwd
+++ b/docs.passwd
@@ -1,1 +1,0 @@
-notroot:x:1:1:notroot:/:/bin/false


### PR DESCRIPTION
It seems that there is no need to explicitly set up any user. Instead we
can just run as a non-zero UID to avoid superuser privileges.

Note: I've chosen a very high UID as it has been suggested elsewhere
that one should avoid clashing with UIDs on the host.